### PR TITLE
fix connect wallet bug

### DIFF
--- a/src/contexts/Transaction.jsx
+++ b/src/contexts/Transaction.jsx
@@ -69,7 +69,7 @@ export function TransactionsProvider({ children }) {
 
     useEffect(() => {
         checkIfWalletIsConnect()
-    }, [transactionCount])
+    }, [transactionCount, currentAccount])
 
     return (
         <TransactionContext.Provider


### PR DESCRIPTION
update src/contexts/Transaction.jsx.
1. when the value of currentAccount changed, can trigger checkIfWalletIsConnect(). 
2. location.reload() may not work in some reason, therefore, need to set currentAccount in useEffect in order to ensure the data can be updated
